### PR TITLE
Enable wayland socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ A [flatpak][] manifest for [JA2 Stracciatella][ja2].
 
 [flatpak]: https://flatpak.org/
 [ja2]: https://github.com/ja2-stracciatella/ja2-stracciatella
+
+## Wayland
+
+The launcher still requires X11, but JA2 itself can run natively on Wayland (which includes support for automatic HiDPI scaling).
+To enable wayland set `$SDL_VIDEODRIVER` to `wayland`.
+To do this persistently only for JA2, run the following command
+
+```
+flatpak override --user --env=SDL_VIDEODRIVER=wayland io.github.ja2-stracciatella
+```

--- a/io.github.ja2-stracciatella.yaml
+++ b/io.github.ja2-stracciatella.yaml
@@ -10,6 +10,7 @@ rename-icon: ja2-stracciatella
 finish-args:
   - '--share=network'
   - '--socket=x11'
+  - '--socket=wayland'
   - '--share=ipc'
   - '--device=dri'
   - '--socket=pulseaudio'


### PR DESCRIPTION
While the FLTK launcher still requires X11, JA2 itself runs on SDL which supports wayland natively.

Users need to set SDL_VIDEODRIVER=wayland to make JA2 run on wayland.

See #4